### PR TITLE
use saveDefaultConfig to load configs to prevent config override

### DIFF
--- a/src/me/tade/mccron/Cron.java
+++ b/src/me/tade/mccron/Cron.java
@@ -34,8 +34,7 @@ public class Cron extends JavaPlugin {
     public void onEnable(){
         log("Loading plugin...");
         log("Loading config...");
-        getConfig().options().copyDefaults(true);
-        saveConfig();
+        this.saveDefaultConfig();
         
         log("Loading commands...");
         getCommand("timer").setExecutor(new TimerCommand(this));


### PR DESCRIPTION
- the previous code here overrides any changes to the current config,
which makes configuration difficult
- this should fix issue
[#2](https://github.com/TheTadeSK/MC-Cron/issues/2)