### PR TITLE
prevented config defaults from being written to existing config

### DIFF
--- a/src/me/tade/mccron/Cron.java
+++ b/src/me/tade/mccron/Cron.java
@@ -36,8 +36,7 @@ public class Cron extends JavaPlugin {
     public void onEnable(){
         log("Loading plugin...");
         log("Loading config...");
-        getConfig().options().copyDefaults(true);
-        saveConfig();
+        saveDefaultConfig();
         
         log("Loading commands...");
         getCommand("timer").setExecutor(new TimerCommand(this));


### PR DESCRIPTION
The config defaults from the jar were always being written to existing configs, meaning that users can't remove the defaults if they want to. `saveDefaultConfig()` won't do anything when the file already exists.